### PR TITLE
github: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,21 @@
+---
+name: "\U0001F41B Bug Report"
+about: Something isn't working as expected
+
+---
+
+## Bug Report
+
+**What version of Rust are you using?**
+<!-- You can run `rustc --version` -->
+
+**What operating system and CPU are you using?**
+<!-- You can run `cat /proc/cpuinfo` -->
+
+**What did you do?**
+<!-- If possible, provide a recipe for reproducing the error. A complete runnable program is good. -->
+
+**What did you expect to see?**
+
+**What did you see instead?**
+

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F680 Feature Request"
+about: I have a suggestion
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the feature you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Teachability, Documentation, Adoption, Migration Strategy**
+<!-- If you can, explain some scenarios how users might use this, situations it would be helpful in. Any API designs, mockups, or diagrams are also helpful. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F914 Question"
+about: Usage question that isn't answered in docs or discussion
+
+---
+
+## Question
+
+<!-- Before asking a question, please check:
+- TiKV Issue List: https://github.com/pingcap/tikv-client/issues?utf8=%E2%9C%93&q=is%3Aissue
+- TiKV Readme: https://github.com/pingcap/tikv
+- TiKV Doc: https://github.com/pingcap/tikv/wiki/TiKV-Documentation
+- TiKV Control Doc: https://pingcap.github.io/docs/tools/tikv-control/
+- TiDB & TiKV Stack Doc: https://pingcap.github.io/docs/
+- Try using Google or StackOverflow to search for the problem.
+-->
+


### PR DESCRIPTION
Adds the issue templates from https://github.com/pingcap/tikv/pull/3237.