### PR TITLE
cargo: Rename package for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tikv-client"
+name = "tikv_client"
 version = "0.0.1"
 license = "apache"
 


### PR DESCRIPTION
You cannot do `extern crate dash-in-name;` unfortunately, so `extern crate underscore_in_name;` is a better choice.

In the long term this would make for:

* `tikv_client`
* `tikv_server`
* `tikv_proto`
* etc...

I could forsee eventually managing to get them all under one `tikv` namespace but I'm not sure how great that would be for compile time, I guess feature flags might work out.